### PR TITLE
Add upper bound for aeson to avoid breaking changes in 0.10

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -144,7 +144,7 @@ Library
   -- Packages needed in order to build this package.
   Build-depends: base >= 4.0 && < 5.0,
                  time,
-                 aeson >= 0.6.1.0,
+                 aeson >= 0.6.1.0 && < 0.10,
                  attoparsec >= 0.10.3.0,
                  bytestring,
                  case-insensitive >= 0.4.0.4,


### PR DESCRIPTION
aeson-0.10 changed `(.:?)` to give `empty` on nulls[0] (whereas it
previously gave `Nothing` on both nulls and missing keys). Documented
upstream[1] but no fix yet.

[0] https://github.com/bos/aeson/issues/287
[1] https://github.com/jwiegley/github/issues/121