### PR TITLE
Add upper bound on http-conduit

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -156,7 +156,7 @@ Library
                  time-locale-compat == 0.1.*,
                  HTTP,
                  network,
-                 http-conduit >= 1.9,
+                 http-conduit >= 1.9 && < 2.2,
                  conduit,
                  failure,
                  http-types,


### PR DESCRIPTION
To avoid breakage with exported http-client types - the package uses a
constructor which was removed in http-client 0.5 (checkStatus).